### PR TITLE
feat: enhance peer discovery logic in bootstrapping command

### DIFF
--- a/cmd/bootstrapping.go
+++ b/cmd/bootstrapping.go
@@ -67,8 +67,16 @@ var bootstrapCmd = &cobra.Command{
 		done := make(chan bool)
 		go acceptConnRoutine(listener, bootstrapper, done)
 
-		peerAddrs := findPeerAddrsViaSsdp(numOfPeers, listenAddrs)
-		client.Logger.Debugf("Found peers via ssdp: %v", peerAddrs)
+		peerAddrs := make([]string, 0)
+
+		if len(common.TssCfg.P2PConfig.PeerAddrs) == 0 {
+			client.Logger.Debugf("No peer addresses found in P2PConfig.PeerAddrs, using SSDP to discover peers")
+			peerAddrs = findPeerAddrsViaSsdp(numOfPeers, listenAddrs)
+			client.Logger.Debugf("Found peers via ssdp: %v", peerAddrs)
+		} else {
+			client.Logger.Debugf("Using configured peer addresses: %v", common.TssCfg.P2PConfig.PeerAddrs)
+			peerAddrs = common.TssCfg.P2PConfig.PeerAddrs
+		}
 
 		go func() {
 			for _, peerAddr := range peerAddrs {


### PR DESCRIPTION
Updated the peer discovery process to first check for configured peer addresses in P2PConfig. If none are found, it falls back to using SSDP for peer discovery. Added debug logging to indicate which method is being used for peer address retrieval.

with this now you can specify peers on the keystore generation:
```
./tss keygen \
--home ./keystore/signer1 \
--vault_name "default" \ 
--parties 3 \ 
--threshold 1 \
--password "123456789" \
--channel_password "123456789" \
--log_level debug \
--channel_id 9936882BEE2 \
--p2p.peer_addrs "/ip4/172.17.0.3/tcp/35515","/ip4/172.17.0.5/tcp/41791","/ip4/172.17.0.5/tcp/41791"
```
